### PR TITLE
 Feature: Add macOS Tahoe to BUG Issue Template OS Selection 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,6 +30,7 @@ body:
         - macOS Sonoma (14.x)
         - macOS Ventura (13.x)
         - macOS Monterey (12.x)
+        - macOS Tahoe (26.x)
         - Other / Not listed
     validations:
       required: true


### PR DESCRIPTION
Let is add macOS 26.3 here for selection as well.